### PR TITLE
Replace the Game category by Development and IDE

### DIFF
--- a/dev.gbstudio.gb-studio.desktop
+++ b/dev.gbstudio.gb-studio.desktop
@@ -7,5 +7,5 @@ Comment[de]=Ein schneller und einfach zu bedienender Drag-and-Drop-Retrospielent
 Icon=dev.gbstudio.gb-studio
 TryExec=gb-studio
 Exec=gb-studio
-Categories=Game;
+Categories=Development;IDE;
 StartupNotify=true

--- a/dev.gbstudio.gb-studio.metainfo.xml
+++ b/dev.gbstudio.gb-studio.metainfo.xml
@@ -230,7 +230,8 @@
   <url type="help">https://www.gbstudio.dev/docs/</url>
   <url type="vcs-browser">https://github.com/chrismaltby/gb-studio</url>
   <categories>
-    <category>Game</category>
+    <category>Development</category>
+    <category>IDE</category>
   </categories>
   <recommends>
     <control>pointing</control>


### PR DESCRIPTION
GB Studio isn't a game but a development tool, so it's odd to find it in the middle of games and emulators. This gives it the same categories as Godot, another game framework and development tool.