### PR TITLE
Update manifest to allow network

### DIFF
--- a/dev.gbstudio.gb-studio.yaml
+++ b/dev.gbstudio.gb-studio.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=x11
   - --device=dri
   - --share=ipc
+  - --share=network
 
 modules:
   - name: gb-studio


### PR DESCRIPTION
GB Studio now can pull plugins from internet, so it should have network permissions.